### PR TITLE
Handle login after sign up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `salt/firebase` will be documented in this file.
 
+## 1.0.3 - 2022-09-12
+[Fix] - Login should occur after signup if user was in admin emails
+
 ## 1.0.2 - 202X-XX-XX
 [Feature] - Adds reset password methods to services
 [Enhancement] - Allows specific emails to signup with a token instead of signup process alone

--- a/src/Services/AuthService.php
+++ b/src/Services/AuthService.php
@@ -35,9 +35,10 @@ class AuthService
         if (! $user) {
             // Configured email domains are allowed to sign up during login
             if (self::emailIsAllowed($firebase_user->email)) {
-                return $this->processSignUpFromToken($token);
+                $user = $this->processSignUpFromToken($token);
+            } else {
+                throw new AuthServiceException('User could not be found.');
             }
-            throw new AuthServiceException('User could not be found.');
         }
 
         $this->login($user, $token);


### PR DESCRIPTION
## Context

Login should take place after sign up when the signup occurs due to an email being an admin email.