### PR TITLE
Fix | Email propagation to firebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `salt/firebase` will be documented in this file.
 
+# 1.0.9 - 2023-10-20
+[Fix] - When email is changed, the new email should be changed in firebase also
+
+
 ## 1.0.3 - 2022-09-12
 [Fix] - Login should occur after signup if user was in admin emails
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `salt/firebase` will be documented in this file.
 
-# 1.0.9 - 2023-10-20
+# 1.0.11 - 2023-10-20
 [Fix] - When email is changed, the new email should be changed in firebase also
 
 

--- a/src/Repositories/CustomUserRepository.php
+++ b/src/Repositories/CustomUserRepository.php
@@ -24,6 +24,12 @@ class CustomUserRepository
      */
     protected function upsertUser(UserRecord $firebase_user, array $user_data = null): User
     {
+        // Propagate the email change through to firebase
+        if ($user_data[email]) {
+            $this->firebase->changeUserEmail($firebase_user->uid, $user_data['email']); 
+        }
+
+        // Update the user model with relevant details
         return User::updateOrCreate(['uid' => $firebase_user->uid], [
             'email' => $firebase_user->email ?? $user_data['email'] ?? '',
             'name' => $firebase_user->displayName ?? $user_data['name'] ?? '',


### PR DESCRIPTION
This PR fixes the issue of email changes in apps not being propagated through to firebase itself. 
i.e. if I update a users email in engauge, the email address changes in the DB, but on firebase the old email persists and then the user can't login. 

On inspection this is because there was actually no logic included to push the email update to firebase. 
This PR adds this. 

This PR does not include a version number tag. 
Once it is merge the tag of `1.0.11` should be added to the main branch and pushed to the repo. 
This version then needs to be utilised on Engauge and other affected repos. 